### PR TITLE
Add sidebar navigation and style improvements

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,3 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+body {
+  @apply bg-gray-50 text-gray-800;
+}

--- a/src/app/json-formatter/page.tsx
+++ b/src/app/json-formatter/page.tsx
@@ -15,13 +15,24 @@ export default function JsonFormatter() {
   }
 
   return (
-    <div className="space-y-2">
+    <div className="space-y-3">
       <h1 className="text-xl font-bold">JSON Formatter</h1>
-      <textarea className="w-full h-40 p-2 border" value={input} onChange={e => setInput(e.target.value)} />
+      <textarea
+        className="w-full h-40 p-2 border border-gray-300 rounded"
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
+      />
       <div>
-        <button className="px-4 py-1 bg-blue-600 text-white" onClick={format}>Format</button>
+        <button
+          className="px-4 py-1 bg-blue-600 text-white rounded hover:bg-blue-700"
+          onClick={format}
+        >
+          Format
+        </button>
       </div>
-      <pre className="bg-gray-100 p-2 whitespace-pre-wrap">{output}</pre>
+      <pre className="bg-gray-100 p-2 whitespace-pre-wrap rounded border">
+        {output}
+      </pre>
     </div>
   )
 }

--- a/src/app/jwt-decoder/page.tsx
+++ b/src/app/jwt-decoder/page.tsx
@@ -27,15 +27,28 @@ export default function JwtDecoder() {
   }
 
   return (
-    <div className="space-y-2">
+    <div className="space-y-3">
       <h1 className="text-xl font-bold">JWT Decoder</h1>
-      <textarea className="w-full h-24 p-2 border" value={token} onChange={e => setToken(e.target.value)} />
+      <textarea
+        className="w-full h-24 p-2 border border-gray-300 rounded"
+        value={token}
+        onChange={(e) => setToken(e.target.value)}
+      />
       <div>
-        <button className="px-4 py-1 bg-blue-600 text-white" onClick={decode}>Decode</button>
+        <button
+          className="px-4 py-1 bg-blue-600 text-white rounded hover:bg-blue-700"
+          onClick={decode}
+        >
+          Decode
+        </button>
       </div>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <pre className="bg-gray-100 p-2 whitespace-pre-wrap">{header}</pre>
-        <pre className="bg-gray-100 p-2 whitespace-pre-wrap">{payload}</pre>
+        <pre className="bg-gray-100 p-2 whitespace-pre-wrap rounded border">
+          {header}
+        </pre>
+        <pre className="bg-gray-100 p-2 whitespace-pre-wrap rounded border">
+          {payload}
+        </pre>
       </div>
     </div>
   )

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import './globals.css'
 import type { Metadata } from 'next'
 import { Inter } from 'next/font/google'
+import Link from 'next/link'
 
 const inter = Inter({ subsets: ['latin'] })
 
@@ -9,14 +10,36 @@ export const metadata: Metadata = {
   description: 'Utility tools',
 }
 
-export default function RootLayout({
-  children,
-}: {
-  children: React.ReactNode
-}) {
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  const nav = [
+    { href: '/', label: 'Home' },
+    { href: '/json-formatter', label: 'JSON Formatter' },
+    { href: '/jwt-decoder', label: 'JWT Decoder' },
+    { href: '/text-diff', label: 'Text Diff' },
+  ]
+
   return (
     <html lang="en">
-      <body className={inter.className + ' p-4'}>{children}</body>
+      <body className={inter.className + ' p-4'}>
+        <div className="flex min-h-screen">
+          <nav className="w-48 pr-4 border-r space-y-2">
+            <h1 className="text-2xl font-bold mb-4">DevTools</h1>
+            <ul className="space-y-1">
+              {nav.map((item) => (
+                <li key={item.href}>
+                  <Link
+                    href={item.href}
+                    className="block px-3 py-2 rounded hover:bg-blue-50"
+                  >
+                    {item.label}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </nav>
+          <main className="flex-1 pl-4">{children}</main>
+        </div>
+      </body>
     </html>
   )
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,14 +1,8 @@
-import Link from 'next/link'
-
 export default function Home() {
   return (
     <main className="space-y-4">
-      <h1 className="text-2xl font-bold">DevTools</h1>
-      <ul className="list-disc list-inside">
-        <li><Link className="text-blue-600 underline" href="/json-formatter">JSON Formatter</Link></li>
-        <li><Link className="text-blue-600 underline" href="/jwt-decoder">JWT Decoder</Link></li>
-        <li><Link className="text-blue-600 underline" href="/text-diff">Text Diff</Link></li>
-      </ul>
+      <h1 className="text-2xl font-bold">Welcome to DevTools</h1>
+      <p>Select a tool from the navigation.</p>
     </main>
   )
 }

--- a/src/app/text-diff/page.tsx
+++ b/src/app/text-diff/page.tsx
@@ -49,18 +49,42 @@ export default function TextDiff() {
   const handle = () => setParts(diff(left, right))
 
   return (
-    <div className="space-y-2">
+    <div className="space-y-3">
       <h1 className="text-xl font-bold">Text Diff</h1>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <textarea className="w-full h-40 p-2 border" value={left} onChange={e => setLeft(e.target.value)} />
-        <textarea className="w-full h-40 p-2 border" value={right} onChange={e => setRight(e.target.value)} />
+        <textarea
+          className="w-full h-40 p-2 border border-gray-300 rounded"
+          value={left}
+          onChange={(e) => setLeft(e.target.value)}
+        />
+        <textarea
+          className="w-full h-40 p-2 border border-gray-300 rounded"
+          value={right}
+          onChange={(e) => setRight(e.target.value)}
+        />
       </div>
       <div>
-        <button className="px-4 py-1 bg-blue-600 text-white" onClick={handle}>Compare</button>
+        <button
+          className="px-4 py-1 bg-blue-600 text-white rounded hover:bg-blue-700"
+          onClick={handle}
+        >
+          Compare
+        </button>
       </div>
-      <pre className="bg-gray-100 p-2 whitespace-pre-wrap">
+      <pre className="bg-gray-100 p-2 whitespace-pre-wrap rounded border">
         {parts.map((p, i) => (
-          <span key={i} className={p.type === 'added' ? 'bg-green-200' : p.type === 'removed' ? 'bg-red-200' : ''}>{p.value}</span>
+          <span
+            key={i}
+            className={
+              p.type === 'added'
+                ? 'bg-green-200'
+                : p.type === 'removed'
+                ? 'bg-red-200'
+                : ''
+            }
+          >
+            {p.value}
+          </span>
         ))}
       </pre>
     </div>


### PR DESCRIPTION
## Summary
- overhaul global style with gray background
- create sidebar layout with navigation links to each tool
- simplify home page message
- enhance form elements and buttons styling for JSON formatter, JWT decoder and Text diff

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e3238884c833082b1b563b8e871a0